### PR TITLE
Add dependency for spring-session-data-redis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,10 @@
 			<artifactId>spring-boot-starter-data-redis</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.session</groupId>
+			<artifactId>spring-session-data-redis</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-thymeleaf</artifactId>
 		</dependency>


### PR DESCRIPTION
Closes #10 
Added dependency for spring-session-data.

Session-data for users should now be saved when that functionality is implemented.