### PR TITLE
Add settings to application.properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=SpringbootGroupProject
+spring.docker.compose.lifecycle-management=start_only
+spring.jpa.hibernate.ddl-auto=none


### PR DESCRIPTION
Closes #12 
Added below to application.properties.
- spring.docker.compose.lifecycle-management=start_only
- spring.jpa.hibernate.ddl-auto=none

Hibernate won't create database anymore and stopping the application won't stop the database.