### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "07:00"
+      
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "07:00"


### PR DESCRIPTION
### Related Issue(s)
Closes #24 

### Proposed Changes
- Adding dependabot to check our dependencies for updates.
- Added checks for github_actions and for maven to dependabot.yml

### Description
With this PR Dependabot version updates will be activated, see picture below. 
Do we want anything else enabled for dependabot?

![image](https://github.com/Win-ther/SpringbootGroupProject/assets/143023413/598587c5-09cb-4ae7-84bd-93494dab106a)
