### PR TITLE
4 service layer for repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,10 @@
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cache</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-core</artifactId>
 		</dependency>

--- a/src/main/java/se/iths/SpringbootGroupProject/SpringbootGroupProjectApplication.java
+++ b/src/main/java/se/iths/SpringbootGroupProject/SpringbootGroupProjectApplication.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
-@EnableCaching
 public class SpringbootGroupProjectApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/se/iths/SpringbootGroupProject/SpringbootGroupProjectApplication.java
+++ b/src/main/java/se/iths/SpringbootGroupProject/SpringbootGroupProjectApplication.java
@@ -2,10 +2,12 @@ package se.iths.SpringbootGroupProject;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableCaching
 public class SpringbootGroupProjectApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/se/iths/SpringbootGroupProject/configurations/CachingConfig.java
+++ b/src/main/java/se/iths/SpringbootGroupProject/configurations/CachingConfig.java
@@ -1,0 +1,26 @@
+package se.iths.SpringbootGroupProject.configurations;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+
+@Configuration
+@EnableCaching
+public class CachingConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+        cacheManager.setCaches(Arrays.asList(
+                new ConcurrentMapCache("messages"),
+                new ConcurrentMapCache("email"),
+                new ConcurrentMapCache("username")));
+        return cacheManager;
+    }
+
+}

--- a/src/main/java/se/iths/SpringbootGroupProject/controllers/GuestController.java
+++ b/src/main/java/se/iths/SpringbootGroupProject/controllers/GuestController.java
@@ -3,6 +3,7 @@ package se.iths.SpringbootGroupProject.controllers;
 import org.springframework.web.bind.annotation.*;
 import se.iths.SpringbootGroupProject.dto.PublicMessageAndUsername;
 import se.iths.SpringbootGroupProject.repositories.MessageRepository;
+import se.iths.SpringbootGroupProject.services.MessageService;
 
 import java.util.List;
 
@@ -10,21 +11,15 @@ import java.util.List;
 @RequestMapping("/api/")
 public class GuestController {
 
-    private final MessageRepository messageRepository;
+    private final MessageService messageService;
 
-    public GuestController(MessageRepository messageRepository) {
-        this.messageRepository = messageRepository;
+    public GuestController(MessageService messageService) {
+        this.messageService = messageService;
     }
 
     @GetMapping("messages")
     List<PublicMessageAndUsername> all(){
-            return messageRepository.findAllByPrivateMessageIsFalse()
-                    .stream()
-                    .map(message -> new PublicMessageAndUsername(
-                            message.getDate(),
-                            message.getTitle(),
-                            message.getMessageBody(),
-                            message.getUser().getUserName())).toList();
+            return messageService.findAllByPrivateMessageIsFalse();
     }
 
 }

--- a/src/main/java/se/iths/SpringbootGroupProject/services/MessageService.java
+++ b/src/main/java/se/iths/SpringbootGroupProject/services/MessageService.java
@@ -1,0 +1,46 @@
+package se.iths.SpringbootGroupProject.services;
+
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import se.iths.SpringbootGroupProject.dto.PublicMessageAndUsername;
+import se.iths.SpringbootGroupProject.repositories.MessageRepository;
+
+import java.util.List;
+
+@Service
+public class MessageService {
+
+    MessageRepository messageRepository;
+
+    public MessageService(MessageRepository messageRepository) {
+        this.messageRepository = messageRepository;
+    }
+
+    @Cacheable("messages")
+    public List<PublicMessageAndUsername> findAllByPrivateMessageIsFalse() {
+        return messageRepository.findAllByPrivateMessageIsFalse()
+                .stream()
+                .map(message -> new PublicMessageAndUsername(
+                        message.getDate(),
+                        message.getTitle(),
+                        message.getMessageBody(),
+                        message.getUser().getUserName())).toList();
+    }
+
+    @CacheEvict(value = "messages", allEntries = true)
+    public void setMessagePrivacy(boolean isPrivate, Long id) {
+        messageRepository.setMessagePrivacy(isPrivate, id);
+    }
+
+    @CacheEvict(value = "messages", allEntries = true)
+    public void editMessage(String updatedBody, Long id) {
+        messageRepository.editMessage(updatedBody, id);
+    }
+
+    @CacheEvict(value = "messages", allEntries = true)
+    public void editTitle(String updatedTitle, Long id) {
+        messageRepository.editTitle(updatedTitle, id);
+    }
+
+}

--- a/src/main/java/se/iths/SpringbootGroupProject/services/MessageService.java
+++ b/src/main/java/se/iths/SpringbootGroupProject/services/MessageService.java
@@ -3,12 +3,14 @@ package se.iths.SpringbootGroupProject.services;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import se.iths.SpringbootGroupProject.dto.PublicMessageAndUsername;
 import se.iths.SpringbootGroupProject.repositories.MessageRepository;
 
 import java.util.List;
 
 @Service
+@Transactional
 public class MessageService {
 
     MessageRepository messageRepository;

--- a/src/main/java/se/iths/SpringbootGroupProject/services/UserService.java
+++ b/src/main/java/se/iths/SpringbootGroupProject/services/UserService.java
@@ -17,12 +17,14 @@ public class UserService {
         this.userRepository = userRepository;
     }
 
-    @Cacheable("firstName")
+    // Needs queries in UserRepository
+    // @Cacheable("firstName")
     public List<User> findByFirstName(String firstName) {
         return userRepository.findByFirstName(firstName);
     }
 
-    @Cacheable("lastName")
+    // Needs queries in UserRepository
+    // @Cacheable("lastName")
     public List<User> findByLastName(String lastName) {
         return userRepository.findByLastName(lastName);
     }

--- a/src/main/java/se/iths/SpringbootGroupProject/services/UserService.java
+++ b/src/main/java/se/iths/SpringbootGroupProject/services/UserService.java
@@ -1,0 +1,45 @@
+package se.iths.SpringbootGroupProject.services;
+
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import se.iths.SpringbootGroupProject.entities.User;
+import se.iths.SpringbootGroupProject.repositories.UserRepository;
+
+import java.util.List;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Cacheable("firstName")
+    public List<User> findByFirstName(String firstName) {
+        return userRepository.findByFirstName(firstName);
+    }
+
+    @Cacheable("lastName")
+    public List<User> findByLastName(String lastName) {
+        return userRepository.findByLastName(lastName);
+    }
+
+    @Cacheable("username")
+    public User findByUserName(String userName) {
+        return userRepository.findByUserName(userName);
+    }
+
+    @Cacheable("email")
+    public User findByEmail(String email) {
+        return userRepository.findByEmail(email);
+    }
+
+    @CacheEvict(value = {"email", "username"}, allEntries = true)
+    public void updateEmail(String email, Long id) {
+        userRepository.updateEmail(email, id);
+    }
+
+}

--- a/src/main/java/se/iths/SpringbootGroupProject/services/UserService.java
+++ b/src/main/java/se/iths/SpringbootGroupProject/services/UserService.java
@@ -3,12 +3,14 @@ package se.iths.SpringbootGroupProject.services;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import se.iths.SpringbootGroupProject.entities.User;
 import se.iths.SpringbootGroupProject.repositories.UserRepository;
 
 import java.util.List;
 
 @Service
+@Transactional
 public class UserService {
 
     private final UserRepository userRepository;


### PR DESCRIPTION
### Related Issue(s)
Closes #4, #21

### Proposed Changes
- Add `spring-boot-starter-cache` dependency in `pom.xml`
- Implement `MessageService` and `UserService` classes
- Enable cache-functionality in services
- Replace `messageRepository` with `messageService` in the `GuestController` class

### Description
This PR introduces enhancements to the application's functionality by implementing caching mechanisms and introducing new service layers. The changes aim to optimize performance and improve overall system efficiency.

Note: _Currently caching for_ `firstName` _and_ `lastName` _is disabled. Enabling caching for these fields would require additional queries in the_ `UserRepository`_. If necessary, we can address this in a separate issue, considering the size of this PR._
