### PR TITLE
Add page to view all messages

### DIFF
--- a/src/main/java/se/iths/springbootgroupproject/configurations/CachingConfig.java
+++ b/src/main/java/se/iths/springbootgroupproject/configurations/CachingConfig.java
@@ -18,6 +18,7 @@ public class CachingConfig {
         SimpleCacheManager cacheManager = new SimpleCacheManager();
         cacheManager.setCaches(Arrays.asList(
                 new ConcurrentMapCache("messages"),
+                new ConcurrentMapCache("publicMessages"),
                 new ConcurrentMapCache("email"),
                 new ConcurrentMapCache("username")));
         return cacheManager;

--- a/src/main/java/se/iths/springbootgroupproject/controllers/GuestController.java
+++ b/src/main/java/se/iths/springbootgroupproject/controllers/GuestController.java
@@ -1,7 +1,7 @@
 package se.iths.springbootgroupproject.controllers;
 
 import org.springframework.web.bind.annotation.*;
-import se.iths.springbootgroupproject.dto.PublicMessageAndUsername;
+import se.iths.springbootgroupproject.dto.MessageAndUsername;
 import se.iths.springbootgroupproject.services.MessageService;
 
 import java.util.List;
@@ -17,7 +17,7 @@ public class GuestController {
     }
 
     @GetMapping("messages")
-    List<PublicMessageAndUsername> all(){
+    List<MessageAndUsername> all(){
             return messageService.findAllByPrivateMessageIsFalse();
     }
 

--- a/src/main/java/se/iths/springbootgroupproject/controllers/WebController.java
+++ b/src/main/java/se/iths/springbootgroupproject/controllers/WebController.java
@@ -7,7 +7,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import se.iths.springbootgroupproject.dto.PublicMessageAndUsername;
+import se.iths.springbootgroupproject.dto.MessageAndUsername;
 import se.iths.springbootgroupproject.services.MessageService;
 
 import java.util.List;
@@ -23,16 +23,28 @@ public class WebController {
     }
 
     @GetMapping("/welcome")
-    public String loadMorePublicMessages(@RequestParam(value = "page", defaultValue = "0") String page, Model model, HttpServletRequest httpServletRequest){
+    public String guestPage(@RequestParam(value = "page", defaultValue = "0") String page, Model model, HttpServletRequest httpServletRequest){
         int p = Integer.parseInt(page);
         if (p < 0) p = 0;
-        List<PublicMessageAndUsername> publicMessages = messageService.findAllByPrivateMessageIsFalse(PageRequest.of(p,10));
+        List<MessageAndUsername> publicMessages = messageService.findAllByPrivateMessageIsFalse(PageRequest.of(p,10));
         int allPublicMessageCount = messageService.findAllByPrivateMessageIsFalse().size();
         model.addAttribute("messages", publicMessages);
         model.addAttribute("httpServletRequest", httpServletRequest);
         model.addAttribute("currentPage",p);
         model.addAttribute("totalPublicMessages", allPublicMessageCount);
         return "welcome";
+    }
+    @GetMapping("/messages")
+    public String messagePage(@RequestParam(value = "page", defaultValue = "0") String page, Model model, HttpServletRequest httpServletRequest){
+        int p = Integer.parseInt(page);
+        if (p < 0) p = 0;
+        List<MessageAndUsername> messages = messageService.findAllMessages(PageRequest.of(p,10));
+        int allMessageCount = messageService.findAllMessages().size();
+        model.addAttribute("messages",messages);
+        model.addAttribute("httpServletRequest",httpServletRequest);
+        model.addAttribute("currentPage",p);
+        model.addAttribute("totalPublicMessages",allMessageCount);
+        return "messages";
     }
 
 }

--- a/src/main/java/se/iths/springbootgroupproject/dto/MessageAndUsername.java
+++ b/src/main/java/se/iths/springbootgroupproject/dto/MessageAndUsername.java
@@ -1,0 +1,7 @@
+package se.iths.springbootgroupproject.dto;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+public record MessageAndUsername(LocalDate date, String title, String messageBody, String userUserName) implements Serializable {
+}

--- a/src/main/java/se/iths/springbootgroupproject/dto/PublicMessageAndUsername.java
+++ b/src/main/java/se/iths/springbootgroupproject/dto/PublicMessageAndUsername.java
@@ -1,7 +1,0 @@
-package se.iths.springbootgroupproject.dto;
-
-import java.io.Serializable;
-import java.time.LocalDate;
-
-public record PublicMessageAndUsername(LocalDate date,String title,String messageBody, String userUserName) implements Serializable {
-}

--- a/src/main/java/se/iths/springbootgroupproject/repositories/MessageRepository.java
+++ b/src/main/java/se/iths/springbootgroupproject/repositories/MessageRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
-import se.iths.springbootgroupproject.dto.PublicMessageAndUsername;
+import se.iths.springbootgroupproject.dto.MessageAndUsername;
 import org.springframework.data.repository.ListPagingAndSortingRepository;
 import se.iths.springbootgroupproject.entities.Message;
 
@@ -14,8 +14,8 @@ import java.util.Optional;
 
 public interface MessageRepository extends ListCrudRepository<Message, Long>, ListPagingAndSortingRepository<Message, Long> {
 
-    List<PublicMessageAndUsername> findAllByPrivateMessageIsFalse();
-    List<PublicMessageAndUsername> findAllByPrivateMessageIsFalse(Pageable pageable);
+    List<MessageAndUsername> findAllByPrivateMessageIsFalse();
+    List<MessageAndUsername> findAllByPrivateMessageIsFalse(Pageable pageable);
     Optional<Message> findByTitle(String title);
 
     @Query("""

--- a/src/main/java/se/iths/springbootgroupproject/services/MessageService.java
+++ b/src/main/java/se/iths/springbootgroupproject/services/MessageService.java
@@ -5,7 +5,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import se.iths.springbootgroupproject.dto.PublicMessageAndUsername;
+import se.iths.springbootgroupproject.dto.MessageAndUsername;
 import se.iths.springbootgroupproject.repositories.MessageRepository;
 
 import java.util.List;
@@ -20,26 +20,46 @@ public class MessageService {
         this.messageRepository = messageRepository;
     }
 
-    @Cacheable("messages")
-    public List<PublicMessageAndUsername> findAllByPrivateMessageIsFalse() {
+    @Cacheable("publicMessages")
+    public List<MessageAndUsername> findAllByPrivateMessageIsFalse() {
         return messageRepository.findAllByPrivateMessageIsFalse();
     }
-    @Cacheable("messages")
-    public List<PublicMessageAndUsername> findAllByPrivateMessageIsFalse(Pageable pageable){
+    @Cacheable("publicMessages")
+    public List<MessageAndUsername> findAllByPrivateMessageIsFalse(Pageable pageable){
         return messageRepository.findAllByPrivateMessageIsFalse(pageable);
     }
+    @Cacheable("messages")
+    public List<MessageAndUsername> findAllMessages(Pageable pageable) {
+        return messageRepository.findAll(pageable).getContent().stream()
+                .map(message -> new MessageAndUsername(
+                        message.getDate(),
+                        message.getTitle(),
+                        message.getMessageBody(),
+                        message.getUser().getUserName()))
+                .toList();
+    }
+    @Cacheable("messages")
+    public List<MessageAndUsername> findAllMessages() {
+        return messageRepository.findAll().stream()
+                .map(message -> new MessageAndUsername(
+                        message.getDate(),
+                        message.getTitle(),
+                        message.getMessageBody(),
+                        message.getUser().getUserName()))
+                .toList();
+    }
 
-    @CacheEvict(value = "messages", allEntries = true)
+    @CacheEvict(value = {"messages", "publicMessages"}, allEntries = true)
     public void setMessagePrivacy(boolean isPrivate, Long id) {
         messageRepository.setMessagePrivacy(isPrivate, id);
     }
 
-    @CacheEvict(value = "messages", allEntries = true)
+    @CacheEvict(value = {"messages", "publicMessages"}, allEntries = true)
     public void editMessage(String updatedBody, Long id) {
         messageRepository.editMessage(updatedBody, id);
     }
 
-    @CacheEvict(value = "messages", allEntries = true)
+    @CacheEvict(value = {"messages", "publicMessages"}, allEntries = true)
     public void editTitle(String updatedTitle, Long id) {
         messageRepository.editTitle(updatedTitle, id);
     }

--- a/src/main/resources/lang/messages.properties
+++ b/src/main/resources/lang/messages.properties
@@ -3,3 +3,4 @@ title=Title
 body=Message Body
 author=Author
 date=Date
+messages.welcome=GGang message list

--- a/src/main/resources/lang/messages_en.properties
+++ b/src/main/resources/lang/messages_en.properties
@@ -3,3 +3,4 @@ title=Title
 body=Message Body
 author=Author
 date=Date
+messages.welcome=GGang message list

--- a/src/main/resources/lang/messages_sv.properties
+++ b/src/main/resources/lang/messages_sv.properties
@@ -3,3 +3,4 @@ title=Titel
 body=Meddelande
 author=Användare
 date=Datum
+messages.welcome=GGängets meddelandelista

--- a/src/main/resources/static/styles.css
+++ b/src/main/resources/static/styles.css
@@ -105,3 +105,11 @@
 .left{
     margin-left: -25px;
 }
+
+.profile-link a {
+    position: fixed;
+    top: 10px;
+    left: 10px;
+    color: inherit;
+    text-decoration: none;
+}

--- a/src/main/resources/templates/messages.html
+++ b/src/main/resources/templates/messages.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>GilGang messages</title>
+    <link href='https://unpkg.com/css.gg@2.0.0/icons/css/globe-alt.css' rel='stylesheet'>
+    <link href='https://unpkg.com/css.gg@2.0.0/icons/css/arrow-right-r.css' rel='stylesheet'>
+    <link href='https://unpkg.com/css.gg@2.0.0/icons/css/arrow-left-r.css' rel='stylesheet'>
+    <link href='https://unpkg.com/css.gg@2.0.0/icons/css/profile.css' rel='stylesheet'>
+    <link rel="stylesheet" href="/static/styles.css">
+    <script defer src="/static/script.js"></script>
+</head>
+<body>
+<div class="dropdown">
+    <i class="gg-globe-alt" id="globe-icon"></i>
+    <div class="dropdown-content" id="dropdown-content">
+        <a th:href="@{${httpServletRequest.requestURI} + '?page=' + ${currentPage} + '&lang=en'}">English</a>
+        <a th:href="@{${httpServletRequest.requestURI} + '?page=' + ${currentPage} + '&lang=sv'}">Svenska</a>
+    </div>
+</div>
+<div class="profile-link">
+    <a th:href="'/web/myprofile'">
+        <i class="gg-profile"></i>
+    </a>
+</div>
+<h1 class="welcome-message" th:text="#{messages.welcome}"></h1>
+<div class="arrows">
+    <a class="left" th:if="${currentPage>0}" th:href="'/web/messages?page='+${currentPage - 1}">
+        <i class="gg-arrow-left-r"></i>
+    </a>
+    <a class="right" th:if="${messages.size()==10 && totalPublicMessages -1 > 10}" th:href="'/web/messages?page='+${currentPage+1}">
+        <i class="gg-arrow-right-r"></i>
+    </a>
+</div>
+<table class="styled-table">
+    <thead>
+    <tr>
+        <th th:text="#{title}"></th>
+        <th th:text="#{body}"></th>
+        <th class ="author-cell-header" th:text="#{author}"></th>
+        <th class ="date-cell-header" th:text="#{date}"></th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="message : ${messages}">
+        <td th:text="${message.title()}">Important Announcement</td>
+        <td th:text="${message.messageBody()}">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</td>
+        <td class="author-cell" th:text="${message.userUserName()}">John Doe</td>
+        <td class="date-cell" th:text="${message.date()}">2024-02-27</td>
+    </tr>
+    </tbody>
+</table>
+
+</body>
+</html>


### PR DESCRIPTION
### Related Issue(s)
Closes #49 

### Proposed Changes
- add messages-page
- change dto-name
- differentiate caching for 'messages' and 'publicMessages'

### Description
- We added a way to see all messages on '/messages'.
- Changed dto-record name from 'PublicMessagesAndUsername' to just 'MessagesAndUsername', 
to be able to use same dto for messages-page.
