### PR TITLE
32 add rest api documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,11 @@
 	</properties>
 	<dependencies>
 		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.4.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>

--- a/src/main/java/se/iths/springbootgroupproject/controllers/GuestController.java
+++ b/src/main/java/se/iths/springbootgroupproject/controllers/GuestController.java
@@ -33,13 +33,13 @@ public class GuestController {
             ),
             @ApiResponse(responseCode = "204", description = "No messages found",
                     content = {@Content(mediaType = "application/json",
-                            array = @ArraySchema(schema = @Schema(implementation = MessageAndUsername.class)))})
+                            array = @ArraySchema(schema = @Schema(implementation = Object.class)))})
     })
     @GetMapping("messages")
     @ResponseStatus(HttpStatus.OK)
     List<MessageAndUsername> all() {
         var messages = messageService.findAllByPrivateMessageIsFalse();
-        if(messages.isEmpty())
+        if (messages.isEmpty())
             throw new ResponseStatusException(HttpStatus.NO_CONTENT);
         return messages;
     }
@@ -53,10 +53,10 @@ public class GuestController {
             ),
             @ApiResponse(responseCode = "204", description = "No messages found",
                     content = {@Content(mediaType = "application/json",
-                            array = @ArraySchema(schema = @Schema(implementation = MessageAndUsername.class)))})
+                            array = @ArraySchema(schema = @Schema(implementation = Object.class)))})
     })
     @GetMapping("messages/users/{id}")
-    List<MessageAndUsername> allPublicUserMessages(@PathVariable Long id){
+    List<MessageAndUsername> allPublicUserMessages(@PathVariable Long id) {
         var messages = messageService.findAllByUserIdAndPrivateMessageIsFalse(id);
         if (messages.isEmpty())
             throw new ResponseStatusException(HttpStatus.NO_CONTENT);

--- a/src/main/java/se/iths/springbootgroupproject/controllers/GuestController.java
+++ b/src/main/java/se/iths/springbootgroupproject/controllers/GuestController.java
@@ -1,6 +1,14 @@
 package se.iths.springbootgroupproject.controllers;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 import se.iths.springbootgroupproject.dto.MessageAndUsername;
 import se.iths.springbootgroupproject.services.MessageService;
 
@@ -16,9 +24,43 @@ public class GuestController {
         this.messageService = messageService;
     }
 
+    @Operation(summary = "Gets all the public messages including authors")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "Found all public messages",
+                    content = {@Content(mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = MessageAndUsername.class)))}
+            ),
+            @ApiResponse(responseCode = "204", description = "No messages found",
+                    content = {@Content(mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = MessageAndUsername.class)))})
+    })
     @GetMapping("messages")
-    List<MessageAndUsername> all(){
-            return messageService.findAllByPrivateMessageIsFalse();
+    @ResponseStatus(HttpStatus.OK)
+    List<MessageAndUsername> all() {
+        var messages = messageService.findAllByPrivateMessageIsFalse();
+        if(messages.isEmpty())
+            throw new ResponseStatusException(HttpStatus.NO_CONTENT);
+        return messages;
+    }
+
+    @Operation(summary = "Gets all public messages from specific author")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "Found all public messages",
+                    content = {@Content(mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = MessageAndUsername.class)))}
+            ),
+            @ApiResponse(responseCode = "204", description = "No messages found",
+                    content = {@Content(mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = MessageAndUsername.class)))})
+    })
+    @GetMapping("messages/users/{id}")
+    List<MessageAndUsername> allPublicUserMessages(@PathVariable Long id){
+        var messages = messageService.findAllByUserIdAndPrivateMessageIsFalse(id);
+        if (messages.isEmpty())
+            throw new ResponseStatusException(HttpStatus.NO_CONTENT);
+        return messages;
     }
 
 }

--- a/src/main/java/se/iths/springbootgroupproject/controllers/GuestController.java
+++ b/src/main/java/se/iths/springbootgroupproject/controllers/GuestController.java
@@ -36,7 +36,6 @@ public class GuestController {
                             array = @ArraySchema(schema = @Schema(implementation = Object.class)))})
     })
     @GetMapping("messages")
-    @ResponseStatus(HttpStatus.OK)
     List<MessageAndUsername> all() {
         var messages = messageService.findAllByPrivateMessageIsFalse();
         if (messages.isEmpty())

--- a/src/main/java/se/iths/springbootgroupproject/repositories/MessageRepository.java
+++ b/src/main/java/se/iths/springbootgroupproject/repositories/MessageRepository.java
@@ -2,6 +2,7 @@ package se.iths.springbootgroupproject.repositories;
 
 import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
@@ -17,6 +18,9 @@ public interface MessageRepository extends ListCrudRepository<Message, Long>, Li
     List<MessageAndUsername> findAllByPrivateMessageIsFalse();
     List<MessageAndUsername> findAllByPrivateMessageIsFalse(Pageable pageable);
     Optional<Message> findByTitle(String title);
+
+    @EntityGraph(attributePaths = "user.userName")
+    List<MessageAndUsername> findAllByUserIdAndPrivateMessageIsFalse(Long id);
 
     @Query("""
             update Message m set m.privateMessage = ?1 where m.id = ?2

--- a/src/main/java/se/iths/springbootgroupproject/services/MessageService.java
+++ b/src/main/java/se/iths/springbootgroupproject/services/MessageService.java
@@ -25,6 +25,10 @@ public class MessageService {
         return messageRepository.findAllByPrivateMessageIsFalse();
     }
     @Cacheable("publicMessages")
+    public List<MessageAndUsername> findAllByUserIdAndPrivateMessageIsFalse(Long id){
+        return messageRepository.findAllByUserIdAndPrivateMessageIsFalse(id);
+    }
+    @Cacheable("publicMessages")
     public List<MessageAndUsername> findAllByPrivateMessageIsFalse(Pageable pageable){
         return messageRepository.findAllByPrivateMessageIsFalse(pageable);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,4 +8,6 @@ spring.messages.fallback-to-system-locale=false
 
 spring.mvc.static-path-pattern=/static/**
 
+springdoc.api-docs.path=/api-docs
+
 #logging.level.org.hibernate.SQL=DEBUG


### PR DESCRIPTION
### Related Issue(s)
Closes #32 

### Proposed Changes
- The Documentation in swagger-ui did not look good with one endpoint only so I added one more, hope you think its ok. 
- Add dependency for documentation of our REST-api endpoints.
- Add another endpoint in our /api/-path to be able to get user specific messages that are public. 

### Description
- Added swagger annotations to our /api/ endpoint(s)
- Added another GetMapping-endpoint to our RESTapi to be able to get public messages from a specific user.
- Added a custom querymethod in messagerepository to be able to fetch public messages from a specific user, using existing DTO.
- Added new querymethod-call from messageService.
- Added OpenApi url to  application.properties.

**Start the application and use the first link to check out the documentation.**
**The second link shows the OpenAPI specifications.**
http://localhost:8080/swagger-ui/index.html
http://localhost:8080/api-docs
