### PR TITLE
Bug crasch on unique username change

### DIFF
--- a/src/main/java/se/iths/springbootgroupproject/controllers/WebController.java
+++ b/src/main/java/se/iths/springbootgroupproject/controllers/WebController.java
@@ -94,7 +94,7 @@ public class WebController {
 
         User user = userService.findByGitHubId(principal.getAttribute("id"));
         if (checkIfUsernameAlreadyExists(userForm.getUserName(),user)) {
-            bindingResult.rejectValue("userName","duplicate", "Not a unique username");
+            bindingResult.rejectValue("userName","duplicate", "Username needs to be unique");
         }
         if(bindingResult.hasErrors()) {
             return "edituser";

--- a/src/main/java/se/iths/springbootgroupproject/controllers/WebController.java
+++ b/src/main/java/se/iths/springbootgroupproject/controllers/WebController.java
@@ -83,14 +83,22 @@ public class WebController {
         return "edituser";
     }
 
+    private boolean checkIfUsernameAlreadyExists(String userName, User user) {
+        return userService.findByUserName(userName).isPresent() && !userName.equals(user.getUserName());
+    }
+
     @PostMapping("/myprofile/edit")
     public String editUserProfile(@Valid @ModelAttribute("formData") EditUserFormData userForm,
                     BindingResult bindingResult,
                     @AuthenticationPrincipal OAuth2User principal) {
+
+        User user = userService.findByGitHubId(principal.getAttribute("id"));
+        if (checkIfUsernameAlreadyExists(userForm.getUserName(),user)) {
+            bindingResult.rejectValue("userName","duplicate", "Not a unique username");
+        }
         if(bindingResult.hasErrors()) {
             return "edituser";
         }
-        User user = userService.findByGitHubId(principal.getAttribute("id"));
         user.setUserName(userForm.getUserName());
         user.setFirstName(userForm.getFirstName());
         user.setLastName(userForm.getLastName());
@@ -99,6 +107,7 @@ public class WebController {
         userService.save(user);
         return "redirect:/web/myprofile";
     }
+
     @GetMapping("/myprofile/create")
     public String createMessage(Model model){
         model.addAttribute("formData", new CreateMessageFormData());

--- a/src/main/java/se/iths/springbootgroupproject/services/UserService.java
+++ b/src/main/java/se/iths/springbootgroupproject/services/UserService.java
@@ -8,6 +8,7 @@ import se.iths.springbootgroupproject.entities.User;
 import se.iths.springbootgroupproject.repositories.UserRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional
@@ -32,8 +33,8 @@ public class UserService {
     }
 
     @Cacheable("username")
-    public User findByUserName(String userName) {
-        return userRepository.findByUserName(userName).orElse(null);
+    public Optional<User> findByUserName(String userName) {
+        return userRepository.findByUserName(userName);
     }
 
     public User findByGitHubId(Integer githubId){


### PR DESCRIPTION
### Proposed Changes
- Fixes crasch when trying to change username to already taken username. Will now give errormessage: "Username needs to be unique".
- Change findByUserName to return Optional<User> instead of just User.


### Description
We will not get error 500 when trying to change username to an already taken username. We can now continue with editing our profile and get an error message instead.