### PR TITLE
Add /api/** to SecurityFilterChain requestmatcher for PermitAll

### DIFF
--- a/src/main/java/se/iths/springbootgroupproject/configurations/SecurityConfig.java
+++ b/src/main/java/se/iths/springbootgroupproject/configurations/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig {
     SecurityFilterChain web(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(requests -> requests
-                        .requestMatchers("/web/welcome", "/login", "/oauth/**", "/logout", "/error**","/static/**").permitAll()
+                        .requestMatchers("/web/welcome", "/login", "/oauth/**", "/logout", "/error**","/static/**","/api/**").permitAll()
                         .requestMatchers("/web/myprofile","/web/myprofile/create","/web/messages","/web/myprofile/edit").authenticated()
                         .anyRequest().denyAll()
                 )


### PR DESCRIPTION
### Related Issue(s)
Closes #71 

### Proposed Changes
- Added /api/** to SecurityFilterChains permitAll RequestMatcher.


### Description
With this fix we can now access all our RESTapi endpoints.