### PR TITLE
9 translation of messages using external api

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -12,3 +12,8 @@ services:
     image: 'redis:latest'
     ports:
       - '6379'
+  libretranslate:
+    image: 'libretranslate/libretranslate:latest'
+    command: '--load-only en,sv'
+    ports:
+      - '5000:5000'

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,14 @@
 			<groupId>org.springframework.boot </groupId>
 			<artifactId>spring-boot-starter-oauth2-client</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.retry</groupId>
+			<artifactId>spring-retry</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-aspects</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-redis</artifactId>

--- a/src/main/java/se/iths/springbootgroupproject/configurations/SecurityConfig.java
+++ b/src/main/java/se/iths/springbootgroupproject/configurations/SecurityConfig.java
@@ -2,6 +2,7 @@ package se.iths.springbootgroupproject.configurations;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -12,6 +13,7 @@ import org.springframework.web.client.RestClient;
 import se.iths.springbootgroupproject.services.github.GithubOAuth2UserService;
 
 @Configuration
+@EnableRetry
 public class SecurityConfig {
 
     private final GithubOAuth2UserService githubOAuth2UserService;
@@ -25,7 +27,8 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests(requests -> requests
                         .requestMatchers("/web/welcome", "/login", "/oauth/**", "/logout", "/error**","/static/**","/api/**").permitAll()
-                        .requestMatchers("/web/myprofile","/web/myprofile/editmessage*","/web/myprofile/create","/web/messages","/web/myprofile/edit").authenticated()
+                        .requestMatchers("/web/myprofile","/web/myprofile/editmessage*","/web/myprofile/create",
+                                "/web/myprofile/edit","/web/messages","/web/messages/translate*").authenticated()
                         .anyRequest().denyAll()
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/se/iths/springbootgroupproject/controllers/WebController.java
+++ b/src/main/java/se/iths/springbootgroupproject/controllers/WebController.java
@@ -15,6 +15,7 @@ import se.iths.springbootgroupproject.dto.EditUserFormData;
 import se.iths.springbootgroupproject.dto.MessageAndUsername;
 import se.iths.springbootgroupproject.entities.Message;
 import se.iths.springbootgroupproject.entities.User;
+import se.iths.springbootgroupproject.services.LibreTranslateService;
 import se.iths.springbootgroupproject.services.MessageService;
 import se.iths.springbootgroupproject.services.UserService;
 
@@ -27,10 +28,12 @@ public class WebController {
 
     private final MessageService messageService;
     private final UserService userService;
+    private final LibreTranslateService libreTranslateService;
 
-    public WebController(MessageService messageService, UserService userService) {
+    public WebController(MessageService messageService, UserService userService, LibreTranslateService libreTranslateService) {
         this.messageService = messageService;
         this.userService = userService;
+        this.libreTranslateService = libreTranslateService;
     }
 
     @GetMapping("/welcome")
@@ -159,5 +162,16 @@ public class WebController {
         return "redirect:/web/myprofile";
     }
 
+    @GetMapping("/messages/translate")
+    public String translateMessage(Model model, @RequestParam("id") Long id) {
+        Message message = messageService.findById(id);
+        String translatedMessage = libreTranslateService.translateMessage(message.getMessageBody());
+        model.addAttribute("title", message.getTitle());
+        model.addAttribute("message", translatedMessage);
+        model.addAttribute("userName",message.getUser().getUserName());
+        model.addAttribute("date", message.getDate());
+        model.addAttribute("lastChanged",message.getLastChanged());
+        return "translatemessage";
+    }
 
 }

--- a/src/main/java/se/iths/springbootgroupproject/controllers/WebController.java
+++ b/src/main/java/se/iths/springbootgroupproject/controllers/WebController.java
@@ -165,8 +165,9 @@ public class WebController {
     @GetMapping("/messages/translate")
     public String translateMessage(Model model, @RequestParam("id") Long id) {
         Message message = messageService.findById(id);
+        String translatedTitle = libreTranslateService.translateMessage(message.getTitle());
         String translatedMessage = libreTranslateService.translateMessage(message.getMessageBody());
-        model.addAttribute("title", message.getTitle());
+        model.addAttribute("title", translatedTitle);
         model.addAttribute("message", translatedMessage);
         model.addAttribute("userName",message.getUser().getUserName());
         model.addAttribute("date", message.getDate());

--- a/src/main/java/se/iths/springbootgroupproject/services/LibreTranslateService.java
+++ b/src/main/java/se/iths/springbootgroupproject/services/LibreTranslateService.java
@@ -1,0 +1,54 @@
+package se.iths.springbootgroupproject.services;
+
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.util.Objects;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
+@Service
+public class LibreTranslateService {
+    private final RestClient restClient;
+
+    public LibreTranslateService(RestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    @Retryable
+    public boolean detectMessageLanguage(String message) {
+        String isEnOrSv = Objects.requireNonNull(restClient.post()
+                .uri("http://localhost:5000/detect")
+                .contentType(APPLICATION_JSON)
+                .accept()
+                .body(String.format("{\"q\":\"%s\"}", message))
+                .retrieve()
+                .body(String.class));
+        return !isEnOrSv.contains("\"en\"");
+    }
+
+    @Retryable
+    public String translateMessage(String message) {
+        String sourceLanguage = "en";
+        String targetLanguage = "sv";
+
+        if(detectMessageLanguage(message)) {
+            sourceLanguage = "sv";
+            targetLanguage = "en";
+        }
+
+        String jsonString = String.format("{\"q\":\"%s\",\"source\":\"%s\",\"target\":\"%s\"}", message, sourceLanguage, targetLanguage);
+
+        return Objects.requireNonNull(restClient.post()
+                        .uri("http://localhost:5000/translate")
+                        .contentType(APPLICATION_JSON)
+                        .accept()
+                        .body(jsonString)
+                        .retrieve()
+                        .body(String.class))
+                .split(":")[1]
+                .replaceAll("[{\"}]","");
+    }
+
+}

--- a/src/main/java/se/iths/springbootgroupproject/services/LibreTranslateService.java
+++ b/src/main/java/se/iths/springbootgroupproject/services/LibreTranslateService.java
@@ -17,28 +17,28 @@ public class LibreTranslateService {
     }
 
     @Retryable
-    public boolean detectMessageLanguage(String message) {
+    public boolean detectMessageLanguage(String text) {
         String isEnOrSv = Objects.requireNonNull(restClient.post()
                 .uri("http://localhost:5000/detect")
                 .contentType(APPLICATION_JSON)
                 .accept()
-                .body(String.format("{\"q\":\"%s\"}", message))
+                .body(String.format("{\"q\":\"%s\"}", text))
                 .retrieve()
                 .body(String.class));
         return !isEnOrSv.contains("\"en\"");
     }
 
     @Retryable
-    public String translateMessage(String message) {
+    public String translateMessage(String text) {
         String sourceLanguage = "en";
         String targetLanguage = "sv";
 
-        if(detectMessageLanguage(message)) {
+        if(detectMessageLanguage(text)) {
             sourceLanguage = "sv";
             targetLanguage = "en";
         }
 
-        String jsonString = String.format("{\"q\":\"%s\",\"source\":\"%s\",\"target\":\"%s\"}", message, sourceLanguage, targetLanguage);
+        String jsonString = String.format("{\"q\":\"%s\",\"source\":\"%s\",\"target\":\"%s\"}", text, sourceLanguage, targetLanguage);
 
         return Objects.requireNonNull(restClient.post()
                         .uri("http://localhost:5000/translate")

--- a/src/main/resources/lang/messages.properties
+++ b/src/main/resources/lang/messages.properties
@@ -22,3 +22,6 @@ image=Image
 updatemessage=Edit message
 lastedit=Last edit
 editedby=By
+translated.message=Translated message
+go.back=Go back
+translate=Translate

--- a/src/main/resources/lang/messages_sv.properties
+++ b/src/main/resources/lang/messages_sv.properties
@@ -22,3 +22,6 @@ image=Bild
 updatemessage=Redigera meddelande
 lastedit=Senast redigerad
 editedby=Av
+translated.message=Översatt meddelande
+go.back=Gå tillbaka
+translate=Översätt

--- a/src/main/resources/static/styles.css
+++ b/src/main/resources/static/styles.css
@@ -147,6 +147,22 @@ td{
     color: inherit;
     text-decoration: none;
 }
+
+.messageContainer {
+    position: relative;
+}
+
+.translateBtn {
+    position: absolute;
+    bottom: -18px;
+    right: 4px;
+}
+
+.go-back-btn {
+    position: absolute;
+    left: 50%;
+}
+
 .edit-button a{
     color: inherit;
     text-decoration: none;

--- a/src/main/resources/templates/messages.html
+++ b/src/main/resources/templates/messages.html
@@ -51,10 +51,10 @@
     <tbody>
     <tr th:each="message : ${messages}">
         <td th:text="${message.title()}">Important Announcement</td>
-        <td>
+        <td class="messageContainer">
             <span th:text="${message.messageBody()}">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
             <a th:href="'/web/messages/translate?id=' +${message.id()}">
-            <button class="translateBtn" th:text="#{translate}">translate</button>
+            <h5 class="translateBtn" th:text="#{translate}">translate</h5>
             </a>
         </td>
         <td class="author-cell" th:text="${message.userUserName()}">John Doe</td>

--- a/src/main/resources/templates/messages.html
+++ b/src/main/resources/templates/messages.html
@@ -51,7 +51,12 @@
     <tbody>
     <tr th:each="message : ${messages}">
         <td th:text="${message.title()}">Important Announcement</td>
-        <td th:text="${message.messageBody()}">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</td>
+        <td>
+            <span th:text="${message.messageBody()}">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</span>
+            <a th:href="'/web/messages/translate?id=' +${message.id()}">
+            <button class="translateBtn" th:text="#{translate}">translate</button>
+            </a>
+        </td>
         <td class="author-cell" th:text="${message.userUserName()}">John Doe</td>
         <td class="date-cell" th:text="${message.date()}">2024-02-27</td>
         <td>

--- a/src/main/resources/templates/translatemessage.html
+++ b/src/main/resources/templates/translatemessage.html
@@ -32,6 +32,6 @@
     </tr>
     </tbody>
 </table>
-<input type="button" th:value="#{back}" onclick="history.back()"/>
+<input class="go-back-btn" type="button" th:value="#{go.back}" onclick="history.back()"/>
 </body>
 </html>

--- a/src/main/resources/templates/translatemessage.html
+++ b/src/main/resources/templates/translatemessage.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Translated GilfMessage</title>
+    <link rel="stylesheet" href="/static/styles.css">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+</head>
+<body>
+<h1 th:text="#{translated.message}"></h1>
+<table class="styled-table">
+    <thead>
+    <tr>
+        <th th:text="#{title}"></th>
+        <th th:text="#{body}"></th>
+        <th class ="author-cell-header" th:text="#{author}"></th>
+        <th class ="date-cell-header" th:text="#{date}"></th>
+        <th class="edit-cell-header" th:text="#{lastedit}"></th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td th:text="${title}">Important Announcement</td>
+        <td th:text="${message}">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</td>
+        <td class="author-cell" th:text="${userName}">John Doe</td>
+        <td class="date-cell" th:text="${date}">2024-02-27</td>
+        <td>
+            <p th:text="${lastChanged}">
+            </p>
+            <p th:if="${lastChanged != null}" th:text="#{editedby}+ ':' +${userName}">
+            </p>
+        </td>
+    </tr>
+    </tbody>
+</table>
+<input type="button" th:value="#{back}" onclick="history.back()"/>
+</body>
+</html>


### PR DESCRIPTION
### Related Issue(s)
Closes #9 

### Proposed Changes
- Loads two languages for 'libretranslate' (en, sv)
- LibreTranslateService-class interacts with LibreTranslate API for language detection and translation. Sends POST requests to '/detect' and '/translate' endpoints. The methods will retry the operation if it fails due to [Retryable](https://www.baeldung.com/spring-retry)-annotation.
- 'translateMessage' in WebController handles GET-request to translate title and message for specific message by its ID and renders to display the translated message 
- Each message in '/web/messages' have a 'translate'-link to get the message translated. When pressed it will lead you to a new page, '/web/messages/translate', where the message is translated. There is a return button to take you back to messages.

### Short Description
- service 'libretranslate' in compose.yaml
- LibreTranslateService-class
- GET method 'translateMessage' in WebController-class
- follows same design for translated message, with a 'go back'-button in translatemessage.html
- 'translation'-link functionality for each message placed in messages.html 
- new requestMatcher, '/web/messages/translate*', for authentication in SecurityConfig-class
- supplement with some words in messages.properties and messages_sv.properties
