### PR TITLE
Refactor editMessage to check if the current user is the same user that created the message

### DIFF
--- a/src/main/java/se/iths/springbootgroupproject/controllers/WebController.java
+++ b/src/main/java/se/iths/springbootgroupproject/controllers/WebController.java
@@ -113,8 +113,14 @@ public class WebController {
 
 
     @GetMapping("/myprofile/editmessage")
-    public String editMessage(Model model, @RequestParam("id") Long id) {
+    public String editMessage(Model model, @RequestParam("id") Long id, @AuthenticationPrincipal OAuth2User principal) {
         Message message = messageService.findById(id);
+        User currectUser = userService.findByGitHubId(principal.getAttribute("id"));
+
+        if (!message.getUser().getId().equals(currectUser.getId())) {
+            return "redirect:/web/myprofile";
+        }
+
         model.addAttribute("formData", new CreateMessageFormData(
                 message.getTitle(),
                 message.getMessageBody(),


### PR DESCRIPTION
### Related Issue(s)
Closes #81 

### Proposed Changes
Checks if the current user is the same user that created the message. 
Meaning that it’s no longer possible to go to ‘/web/myprofile/editmessage?id=1’ to edit ‘Jame SBond 070’ message, it will redirect back to ‘/web/myprofile’ if trying to enter edit mode for that message.
